### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/backend/api/stock_api.py
+++ b/backend/api/stock_api.py
@@ -29,7 +29,14 @@ async def get_stock_data(
 ):
     try:
         # 构建文件路径
-        file_path = os.path.join(os.path.dirname(__file__), "..", "data", f"{symbol}_stock_data.csv")
+        base_path = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "data"))
+        file_path = os.path.normpath(os.path.join(base_path, f"{symbol}_stock_data.csv"))
+        
+        # 验证路径是否在允许的目录中
+        if not file_path.startswith(base_path):
+            logger.error(f"非法路径访问尝试: {file_path}")
+            raise HTTPException(status_code=400, detail="非法路径访问")
+        
         logger.debug(f"尝试读取文件: {file_path}")
         
         # 检查文件是否存在


### PR DESCRIPTION
Potential fix for [https://github.com/danielviki/StockReview/security/code-scanning/1](https://github.com/danielviki/StockReview/security/code-scanning/1)

To fix the issue, we need to ensure that the constructed `file_path` is confined to a safe directory. This can be achieved by normalizing the path using `os.path.normpath` and verifying that the resulting path starts with the intended base directory. This approach prevents directory traversal attacks by ensuring that the resolved path does not escape the intended directory.

Steps to fix:
1. Normalize the constructed `file_path` using `os.path.normpath`.
2. Verify that the normalized path starts with the intended base directory.
3. Raise an exception if the path is outside the allowed directory.

Changes will be made to the `file_path` construction and validation logic in the `get_stock_data` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
